### PR TITLE
Add ability to configure default host information.

### DIFF
--- a/Adapter/LocalWithHost.php
+++ b/Adapter/LocalWithHost.php
@@ -16,15 +16,28 @@ class LocalWithHost extends Local
     public function __construct(
         $root,
         RequestStack $requestStack,
-        $webpath
+        $webpath,
+        $defaults
     ) {
         parent::__construct($root);
+
         $request = $requestStack->getCurrentRequest();
         if (null !== $request) {
             $this->scheme = $request->getScheme();
             $this->httpHost = $request->getHttpHost();
             $this->port = $request->getPort();
+        } else {
+            if (isset($defaults['httpHost'])) {
+                $this->httpHost = $defaults['httpHost'];
+            }
+            if (isset($defaults['port'])) {
+                $this->port = $defaults['port'];
+            }
+            if (isset($defaults['scheme'])) {
+                $this->scheme = $defaults['scheme'];
+            }
         }
+
         $this->webpath = $webpath;
     }
 

--- a/Adapter/LocalWithHost.php
+++ b/Adapter/LocalWithHost.php
@@ -8,9 +8,9 @@ use Symfony\Component\HttpFoundation\RequestStack;
 class LocalWithHost extends Local
 {
     private $requestStack;
-    private $scheme;
-    private $httpHost;
-    private $port;
+    private $scheme = "http";
+    private $httpHost = "localhost";
+    private $port = 80;
     private $webpath;
 
     public function __construct(
@@ -20,9 +20,11 @@ class LocalWithHost extends Local
     ) {
         parent::__construct($root);
         $request = $requestStack->getCurrentRequest();
-        $this->scheme = $request->getScheme();
-        $this->httpHost = $request->getHttpHost();
-        $this->port = $request->getPort();
+        if (null !== $request) {
+            $this->scheme = $request->getScheme();
+            $this->httpHost = $request->getHttpHost();
+            $this->port = $request->getPort();
+        }
         $this->webpath = $webpath;
     }
 

--- a/DependencyInjection/Factory/Adapter/LocalWithHostFactory.php
+++ b/DependencyInjection/Factory/Adapter/LocalWithHostFactory.php
@@ -20,6 +20,7 @@ class LocalWithHostFactory implements AdapterFactoryInterface
             ->setDefinition($id, new DefinitionDecorator('oneup_flysystem.adapter.local_with_host'))
             ->replaceArgument(0, $config['directory'])
             ->replaceArgument(2, $config['webpath'])
+            ->replaceArgument(3, $config['defaults'])
         ;
     }
 
@@ -29,6 +30,13 @@ class LocalWithHostFactory implements AdapterFactoryInterface
             ->children()
                 ->scalarNode('directory')->isRequired()->end()
                 ->scalarNode('webpath')->isRequired()->end()
+                ->arrayNode('defaults')
+                    ->children()
+                        ->scalarNode('scheme')->end()
+                        ->scalarNode('httpHost')->end()
+                        ->scalarNode('port')->end()
+                    ->end()
+                ->end()
             ->end()
         ;
     }

--- a/Resources/config/adapters.xml
+++ b/Resources/config/adapters.xml
@@ -8,6 +8,7 @@
                    <argument /><!-- Directory -->
                    <argument type="service" id="request_stack"/><!-- RequestStack -->
                    <argument /><!-- Webpath -->
+                   <argument on-invalid="ignore"/><!-- Defaults -->
                </service>
                <service id="oneup_flysystem.adapter.local" class="League\Flysystem\Adapter\Local" abstract="true" public="false">
                    <argument /><!-- Directory -->


### PR DESCRIPTION
Not all situations, such as command line applications, will have a current request.  In those situations it is convienent to be able to have reasonable default values available, which are overrideable through configuration.

With this PR we can now specify things like:

``` yaml
local_with_host:
    directory: %kernel.root_dir%/../../dist/uploads
    webpath: 'uploads'
    defaults:
        httpHost: local.goformative.com
```
